### PR TITLE
Allow partial string matching in search

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -119,12 +119,12 @@ Format: `find KEYWORD [MORE_KEYWORDS]`
 * The search is case-insensitive. e.g `hans` will match `Hans`
 * The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
 * Only the name is searched.
-* Only full words will be matched e.g. `Han` will not match `Hans`
+* Partial names will also be matched e.g. `Han` will match `Hans`
 * Beneficiaries matching at least one keyword will be returned (i.e. `OR` search).
   e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
 
 Examples:
-* `find John` returns `john` and `John Doe`
+* `find John` returns `johnny` and `John Doe`
 * `find alex david` returns `Alex Yeoh`, `David Li`<br>
   ![result for 'find alex david'](images/findAlexDavidResult.png)
 

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -39,6 +39,38 @@ public class StringUtil {
     }
 
     /**
+     * Returns true if the {@code sentence} contains the {@code partialWord}.
+     *   Ignores case, but a full word match is NOT required.
+     *   <br>examples:<pre>
+     *       containsPartialWordIgnoreCase("ABc def", "abc") == true
+     *       containsPartialWordIgnoreCase("ABc def", "DEF") == true
+     *       containsPartialWordIgnoreCase("ABc def", "AB") == true // full word match not required
+     *       containsPartialWordIgnoreCase("ABc def", "fg") == false
+     *       </pre>
+     * @param sentence cannot be null
+     * @param partialWord cannot be null, cannot be empty, must be a single word
+     */
+    public static boolean containsPartialWordIgnoreCase(String sentence, String partialWord) {
+        requireNonNull(sentence);
+        requireNonNull(partialWord);
+
+        // prepare partial word (using lower case for case insensitive search)
+        String preppedPartialWord = partialWord.trim().toLowerCase();
+        checkArgument(!preppedPartialWord.isEmpty(), "Parital Word parameter cannot be empty");
+        checkArgument(preppedPartialWord.split("\\s+").length == 1,
+                "Partial Word parameter should be a single word");
+
+        // prepare sentence (using lower case for case insensitive search)
+        String preppedSentence = sentence.toLowerCase();
+
+        // There is no need to check each individual word in person name for contains preppedWord because
+        // 1) if a word in person name contains prepped word -> preppedSentence contains preppedWord
+        // 2) if preppedSentence contains prepped word -> a word in person name contains prepped word
+        // 2 is because preppedWord doesn't have any spaces
+        return preppedSentence.contains(preppedPartialWord);
+    }
+
+    /**
      * Returns a detailed message of the t, including the stack trace.
      */
     public static String getDetails(Throwable t) {

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -56,7 +56,7 @@ public class StringUtil {
 
         // prepare partial word (using lower case for case insensitive search)
         String preppedPartialWord = partialWord.trim().toLowerCase();
-        checkArgument(!preppedPartialWord.isEmpty(), "Parital Word parameter cannot be empty");
+        checkArgument(!preppedPartialWord.isEmpty(), "Partial Word parameter cannot be empty");
         checkArgument(preppedPartialWord.split("\\s+").length == 1,
                 "Partial Word parameter should be a single word");
 

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -19,7 +19,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .anyMatch(keyword -> StringUtil.containsPartialWordIgnoreCase(person.getName().fullName, keyword));
     }
 
     @Override

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -123,6 +123,88 @@ public class StringUtilTest {
         assertTrue(StringUtil.containsWordIgnoreCase("AAA bBb ccc  bbb", "bbB"));
     }
 
+    //---------------- Tests for containsPartialWordIgnoreCase --------------------------------------
+
+    /*
+     * Invalid equivalence partitions for partialWord: null, empty, multiple words
+     * Invalid equivalence partitions for sentence: null
+     * The four test cases below test one invalid input at a time.
+     */
+
+    @Test
+    public void containsPartialWordIgnoreCase_nullWord_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> StringUtil.containsPartialWordIgnoreCase("typical sentence",
+                null));
+    }
+
+    @Test
+    public void containsPartialWordIgnoreCase_emptyWord_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, "Partial Word parameter cannot be empty", ()
+                -> StringUtil.containsPartialWordIgnoreCase("typical sentence", "  "));
+    }
+
+    @Test
+    public void containsPartialWordIgnoreCase_multipleWords_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, "Partial Word parameter should be a single word", ()
+                -> StringUtil.containsPartialWordIgnoreCase("typical sentence", "aaa BBB"));
+    }
+
+    @Test
+    public void containsPartialWordIgnoreCase_nullSentence_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> StringUtil.containsPartialWordIgnoreCase(null, "abc"));
+    }
+
+    /*
+     * Valid equivalence partitions for word:
+     *   - any word
+     *   - word containing symbols/numbers
+     *   - word with leading/trailing spaces
+     *
+     * Valid equivalence partitions for sentence:
+     *   - empty string
+     *   - one word
+     *   - multiple words
+     *   - sentence with extra spaces
+     *
+     * Possible scenarios returning true:
+     *   - partialWord is a complete word in sentence
+     *   - partialWord is part of a word in sentence
+     *   - partialWord is part of multiple words in sentence
+     *
+     * Possible scenarios returning false:
+     *   - sentence does not contain partialWord
+     *   - sentence matches part of the partialWord
+     *
+     * The test method below tries to verify all above with a reasonably low number of test cases.
+     */
+
+    @Test
+    public void containsPartialWordIgnoreCase_validInputs_correctResult() {
+
+        // Empty sentence
+        assertFalse(StringUtil.containsPartialWordIgnoreCase("", "abc")); // Boundary case
+        assertFalse(StringUtil.containsPartialWordIgnoreCase("    ", "123"));
+
+        // Matches a partial word only
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("aaa bbb ccc",
+                "bb")); // Sentence word bigger than query word
+        assertFalse(StringUtil.containsPartialWordIgnoreCase("aaa bbb ccc",
+                "bbbb")); // Query word bigger than sentence word
+
+        // Matches word in the sentence, different upper/lower case letters
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("aaa bBb ccc", " Bbb")); // First word (boundary case)
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("aaa bBb ccc@1", "CCc@1")); // Last word (boundary case)
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("  AAA   bBb   ccc  ", "aaa")); // Sentence has extra spaces
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("Aaa", "aaa")); // Only one word in sentence (boundary case)
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("aaa bbb ccc", "  ccc  ")); // Leading/trailing spaces
+
+        // part of multiple words in sentence
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("AAA bBb ccc  bbb", "bB"));
+
+        // sentence does not contain partial word
+        assertFalse(StringUtil.containsPartialWordIgnoreCase("abc def", "fg"));
+    }
+
     //---------------- Tests for getDetails --------------------------------------
 
     /*


### PR DESCRIPTION
Fixes #54 

## Changes made
1) Added partial string searching for find command. So now find "john yeo" will find "johnny", "john doe", and "alex yeoh".
2) Added new tests for the enhancement
3) Updated the UG accordingly

## Possible further enhancements
1) Possibly enforce a minimum length for the search string so not too many matches are returned
2) Possibly implement some sort of sorting in the filtered list displayed so more closely matching names are shown first