### PR TITLE
Use appropriate colors for logging

### DIFF
--- a/src/main/java/careconnect/commons/core/LogFormatter.java
+++ b/src/main/java/careconnect/commons/core/LogFormatter.java
@@ -1,0 +1,86 @@
+package careconnect.commons.core;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+/**
+ * LogFormatter adapted from Manuel Moser's implementation. See below:
+ * https://stackoverflow.com/questions/53211694/change-color-and-format-of-java-util-logging-logger-output-in-eclipse
+ */
+public class LogFormatter extends Formatter {
+    // ANSI escape code
+    public static final String ANSI_RESET = "\u001B[0m";
+    public static final String ANSI_BLACK = "\u001B[30m";
+    public static final String ANSI_RED = "\u001B[31m";
+    public static final String ANSI_GREEN = "\u001B[32m";
+    public static final String ANSI_YELLOW = "\u001B[33m";
+    public static final String ANSI_BLUE = "\u001B[34m";
+    public static final String ANSI_PURPLE = "\u001B[35m";
+    public static final String ANSI_CYAN = "\u001B[36m";
+    public static final String ANSI_WHITE = "\u001B[37m";
+
+    /**
+     * Creates a formatted string containing the datetime,
+     * log level, class, followed by the message of the log.
+     * The string will be colored according to the log level.
+     *
+     * @param record the log record to be formatted.
+     * @return the formatted log string
+     */
+    @Override
+    public String format(LogRecord record) {
+        StringBuilder builder = new StringBuilder();
+
+        // Set log color based on logging level
+        Level logLevel = record.getLevel();
+        if (logLevel.equals(Level.WARNING)) {
+            builder.append(ANSI_YELLOW);
+        } else if (logLevel.equals(Level.SEVERE)) {
+            builder.append(ANSI_RED);
+        } else {
+            builder.append(ANSI_WHITE);
+        }
+
+        // Datetime
+        builder.append(calcDate(record.getMillis()));
+
+        // Log level
+        builder.append(" [");
+        builder.append(record.getLevel().getName());
+        builder.append("]");
+
+        // Source class
+        builder.append(" [");
+        builder.append(record.getSourceClassName());
+        builder.append("]");
+
+        // Log message
+        builder.append(" - ");
+        builder.append(record.getMessage());
+
+        Object[] params = record.getParameters();
+
+        if (params != null) {
+            builder.append("\t");
+            for (int i = 0; i < params.length; i++) {
+                builder.append(params[i]);
+                if (i < params.length - 1) {
+                    builder.append(", ");
+                }
+            }
+        }
+
+        builder.append(ANSI_RESET);
+        builder.append("\n");
+        return builder.toString();
+    }
+
+    private String calcDate(long millisecond) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        Date resultdate = new Date(millisecond);
+        return dateFormat.format(resultdate);
+    }
+}

--- a/src/main/java/careconnect/commons/core/LogsCenter.java
+++ b/src/main/java/careconnect/commons/core/LogsCenter.java
@@ -8,7 +8,6 @@ import java.util.logging.ConsoleHandler;
 import java.util.logging.FileHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.logging.SimpleFormatter;
 
 /**
  * Configures and manages loggers and handlers, including their logging level
@@ -75,11 +74,11 @@ public class LogsCenter {
     }
 
     /**
-     * Creates a logger named 'ab3', containing a {@code ConsoleHandler} and a {@code FileHandler}.
+     * Creates a logger named 'careconnect', containing a {@code ConsoleHandler} and a {@code FileHandler}.
      * Sets it as the {@code baseLogger}, to be used as the parent logger of all other loggers.
      */
     private static void setBaseLogger() {
-        baseLogger = Logger.getLogger("ab3");
+        baseLogger = Logger.getLogger("careconnect");
         baseLogger.setUseParentHandlers(false);
         removeHandlers(baseLogger);
 
@@ -88,13 +87,14 @@ public class LogsCenter {
 
         // add a ConsoleHandler to log to the console
         ConsoleHandler consoleHandler = new ConsoleHandler();
+        consoleHandler.setFormatter(new LogFormatter());
         consoleHandler.setLevel(Level.ALL);
         baseLogger.addHandler(consoleHandler);
 
         // add a FileHandler to log to a file
         try {
             FileHandler fileHandler = new FileHandler(LOG_FILE, MAX_FILE_SIZE_IN_BYTES, MAX_FILE_COUNT, true);
-            fileHandler.setFormatter(new SimpleFormatter());
+            fileHandler.setFormatter(new LogFormatter());
             fileHandler.setLevel(Level.ALL);
             baseLogger.addHandler(fileHandler);
         } catch (IOException e) {


### PR DESCRIPTION
Closes #87 

This PR implements a new LogFormatter class which correctly colors the log messages based on the log level. The LogFormatter also uses a new format`datetime [LOG LEVEL] [SOURCE CLASS] - log message` which I believe is more readable

Current:
<img width="1088" alt="Screenshot 2024-10-26 at 12 11 54 AM" src="https://github.com/user-attachments/assets/55198b11-5c7e-40f7-9cc0-85c9434e5c98">

Suggested change:
<img width="1088" alt="Screenshot 2024-10-26 at 12 10 31 AM" src="https://github.com/user-attachments/assets/9b5e2ac6-d07e-4f13-a135-2f773698491a">
