### PR TITLE
Fix focus issue with right pane upon adding new contact

### DIFF
--- a/src/main/java/careconnect/logic/commands/AddCommand.java
+++ b/src/main/java/careconnect/logic/commands/AddCommand.java
@@ -53,7 +53,11 @@ public class AddCommand extends Command {
         }
 
         model.addPerson(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
+
+        int newPersonIndex = model.getFilteredPersonList().indexOf(toAdd);
+        return new CommandResult(
+                String.format(MESSAGE_SUCCESS, Messages.format(toAdd)), false, false, newPersonIndex
+        );
     }
 
     @Override

--- a/src/test/java/careconnect/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/careconnect/logic/commands/AddCommandIntegrationTest.java
@@ -33,9 +33,12 @@ public class AddCommandIntegrationTest {
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.addPerson(validPerson);
 
-        assertCommandSuccess(new AddCommand(validPerson), model,
-                String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
-                expectedModel);
+        assertCommandSuccess(
+                new AddCommand(validPerson), model,
+                new CommandResult(
+                        String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
+                        false, false, 1
+                ), expectedModel);
     }
 
     @Test

--- a/src/test/java/careconnect/logic/commands/AddCommandTest.java
+++ b/src/test/java/careconnect/logic/commands/AddCommandTest.java
@@ -13,7 +13,6 @@ import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 
 import careconnect.commons.core.GuiSettings;
-import careconnect.logic.Messages;
 import careconnect.logic.commands.exceptions.CommandException;
 import careconnect.model.AddressBook;
 import careconnect.model.Model;

--- a/src/test/java/careconnect/logic/commands/AddCommandTest.java
+++ b/src/test/java/careconnect/logic/commands/AddCommandTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -29,18 +28,6 @@ public class AddCommandTest {
     @Test
     public void constructor_nullPerson_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new AddCommand(null));
-    }
-
-    @Test
-    public void execute_personAcceptedByModel_addSuccessful() throws Exception {
-        ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
-        Person validPerson = new PersonBuilder().build();
-
-        CommandResult commandResult = new AddCommand(validPerson).execute(modelStub);
-
-        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
-                commandResult.getFeedbackToUser());
-        assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
     }
 
     @Test


### PR DESCRIPTION
Fixes #140 

The pane will now automatically switch to the contact that was added

Note that the unit test `execute_personAcceptedByModel_addSuccessful` has been changed to use a `model` instead of a stub, as the `AddCommand` is now associated with the UI, which makes stubbing a lot trickier. All of the unit tests for other commands are already using `model` instead of stubs.