### PR TITLE
Home Address gets truncated if it's too long

### DIFF
--- a/src/main/java/careconnect/ui/PersonDetailCard.java
+++ b/src/main/java/careconnect/ui/PersonDetailCard.java
@@ -13,6 +13,7 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
+import javafx.scene.text.Text;
 
 /**
  * An UI component that displays detailed information of a {@code Person} in the right pane of
@@ -41,7 +42,7 @@ public class PersonDetailCard extends UiPart<Region> {
     @FXML
     private Label phone;
     @FXML
-    private Label address;
+    private Text address;
     @FXML
     private Label addressLink;
     @FXML

--- a/src/main/resources/view/PersonDetailCard.fxml
+++ b/src/main/resources/view/PersonDetailCard.fxml
@@ -8,6 +8,8 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.text.TextFlow?>
+<?import javafx.scene.text.Text?>
 <?import javafx.scene.layout.VBox?>
 <HBox xmlns:fx="http://javafx.com/fxml/1" id="cardPane" fx:id="cardPane"
       xmlns="http://javafx.com/javafx/17">
@@ -39,17 +41,19 @@
                 <VBox>
                     <Label styleClass="label-title" text="Home Address"/>
                     <HBox spacing="4" VBox.vgrow="ALWAYS">
-                        <Label fx:id="address" styleClass="label-content" text="\$address"/>
-                        <Label fx:id="addressLink" styleClass="link" text="(click to view map)"/>
+                        <TextFlow VBox.vgrow="ALWAYS">
+                            <Text fx:id="address" styleClass="label-content" text="\$address"/>
+                            <Label fx:id="addressLink" styleClass="link" text="(click to view map)"/>
+                        </TextFlow>
                     </HBox>
                 </VBox>
-            </VBox>
-            <VBox fx:id="logsList" minWidth="380" styleClass="pane" >
-                <padding>
-                    <Insets left="10.0" top="10.0"/>
-                </padding>
-                <StackPane fx:id="logsListPanelPlaceHolder" styleClass="pane-without-border"
-                           VBox.vgrow="ALWAYS"/>
+                <VBox fx:id="logsList" minWidth="380" styleClass="pane" >
+                    <padding>
+                        <Insets left="10.0" top="10.0"/>
+                    </padding>
+                    <StackPane fx:id="logsListPanelPlaceHolder" styleClass="pane-without-border"
+                               VBox.vgrow="ALWAYS"/>
+                </VBox>
             </VBox>
         </VBox>
         <rowConstraints>

--- a/src/main/resources/view/PersonDetailCard.fxml
+++ b/src/main/resources/view/PersonDetailCard.fxml
@@ -43,7 +43,7 @@
                     <HBox spacing="4" VBox.vgrow="ALWAYS">
                         <TextFlow VBox.vgrow="ALWAYS">
                             <Text fx:id="address" styleClass="label-content" text="\$address"/>
-                            <Label fx:id="addressLink" styleClass="link" text="(click to view map)"/>
+                            <Label fx:id="addressLink" styleClass="link" text=" (click to view map)"/>
                         </TextFlow>
                     </HBox>
                 </VBox>


### PR DESCRIPTION
fixes #139 by wrapping address text 


![Screenshot 2024-11-01 at 12 15 28 AM](https://github.com/user-attachments/assets/a2793330-e4b2-4a46-9440-cb0c69daacb8)
