### PR TITLE
feat: switch focus on shift + tab key press

### DIFF
--- a/src/main/java/careconnect/ui/CommandBox.java
+++ b/src/main/java/careconnect/ui/CommandBox.java
@@ -5,6 +5,8 @@ import careconnect.logic.autocompleter.exceptions.AutocompleteException;
 import careconnect.logic.commands.CommandResult;
 import careconnect.logic.commands.exceptions.CommandException;
 import careconnect.logic.parser.exceptions.ParseException;
+import careconnect.ui.MainWindow.FocusItemUpdater;
+import careconnect.ui.MainWindow.FocusItems;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
@@ -31,13 +33,17 @@ public class CommandBox extends UiPart<Region> implements ShiftTabFocusable {
      * Creates a {@code CommandBox} with the given {@code CommandExecutor}.
      */
     public CommandBox(CommandExecutor commandExecutor, CommandAutocompleter commandAutocompleter,
-                      SyntaxValidator syntaxValidator) {
+                      SyntaxValidator syntaxValidator, FocusItemUpdater focusItemUpdater) {
         super(FXML);
         this.commandExecutor = commandExecutor;
         this.commandAutocompleter = commandAutocompleter;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
         this.syntaxValidator = syntaxValidator;
+        commandTextField.setOnMousePressed(event -> {
+            focusItemUpdater.updateCurrentFocusItem(FocusItems.COMMAND_BOX_ITEM);
+        });
+
     }
 
     @Override

--- a/src/main/java/careconnect/ui/CommandBox.java
+++ b/src/main/java/careconnect/ui/CommandBox.java
@@ -15,7 +15,7 @@ import javafx.scene.layout.Region;
 /**
  * The UI component that is responsible for receiving user command inputs.
  */
-public class CommandBox extends UiPart<Region> {
+public class CommandBox extends UiPart<Region> implements ShiftTabFocusable {
 
     public static final String ERROR_STYLE_CLASS = "error";
     private static final String FXML = "CommandBox.fxml";
@@ -38,6 +38,11 @@ public class CommandBox extends UiPart<Region> {
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
         this.syntaxValidator = syntaxValidator;
+    }
+
+    @Override
+    public void focus() {
+        commandTextField.requestFocus();
     }
 
     /**

--- a/src/main/java/careconnect/ui/LogListPanel.java
+++ b/src/main/java/careconnect/ui/LogListPanel.java
@@ -5,6 +5,8 @@ import java.util.logging.Logger;
 
 import careconnect.commons.core.LogsCenter;
 import careconnect.model.log.Log;
+import careconnect.ui.MainWindow.FocusItemUpdater;
+import careconnect.ui.MainWindow.FocusItems;
 import javafx.collections.FXCollections;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
@@ -23,10 +25,13 @@ public class LogListPanel extends UiPart<Region> implements ShiftTabFocusable {
     /**
      * Creates a {@code LogsListPanel} with the given immutable {@code List}.
      */
-    public LogListPanel(List<Log> logs) {
+    public LogListPanel(List<Log> logs, FocusItemUpdater focusItemUpdater) {
         super(FXML);
         logListView.setItems(FXCollections.observableList(logs));
         logListView.setCellFactory(cell -> new LogListViewCell());
+        logListView.setOnMousePressed(event -> {
+            focusItemUpdater.updateCurrentFocusItem(FocusItems.LOG_LIST_ITEM);
+        });
     }
 
     @Override
@@ -54,5 +59,9 @@ public class LogListPanel extends UiPart<Region> implements ShiftTabFocusable {
                 setGraphic(new LogCard(log, getIndex() + 1).getRoot());
             }
         }
+    }
+
+    protected boolean isLogListEmpty() {
+        return this.logListView.getItems().isEmpty();
     }
 }

--- a/src/main/java/careconnect/ui/LogListPanel.java
+++ b/src/main/java/careconnect/ui/LogListPanel.java
@@ -13,7 +13,7 @@ import javafx.scene.layout.Region;
 /**
  * Panel containing the list of logs.
  */
-public class LogListPanel extends UiPart<Region> {
+public class LogListPanel extends UiPart<Region> implements ShiftTabFocusable {
     private static final String FXML = "LogListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(LogListPanel.class);
 
@@ -27,6 +27,11 @@ public class LogListPanel extends UiPart<Region> {
         super(FXML);
         logListView.setItems(FXCollections.observableList(logs));
         logListView.setCellFactory(cell -> new LogListViewCell());
+    }
+
+    @Override
+    public void focus() {
+        this.logListView.requestFocus();
     }
 
     /**

--- a/src/main/java/careconnect/ui/MainWindow.java
+++ b/src/main/java/careconnect/ui/MainWindow.java
@@ -6,10 +6,12 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.logging.Logger;
 
+import careconnect.Main;
 import careconnect.commons.core.GuiSettings;
 import careconnect.commons.core.LogsCenter;
 import careconnect.logic.Logic;
 import careconnect.logic.autocompleter.exceptions.AutocompleteException;
+import careconnect.logic.commands.Command;
 import careconnect.logic.commands.CommandResult;
 import careconnect.logic.commands.exceptions.CommandException;
 import careconnect.logic.parser.exceptions.ParseException;
@@ -18,6 +20,8 @@ import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextInputControl;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;
@@ -36,7 +40,10 @@ public class MainWindow extends UiPart<Stage> {
     private final PersonDetailFallback personDetailFallback = new PersonDetailFallback();
     private final Stage primaryStage;
     private final Logic logic;
+    private FocusItems currentFocusItem;
     // Independent Ui parts residing in this Ui container
+    private PersonDetailCard selectedPersonDetailCard;
+    private CommandBox commandBox;
     private PersonListPanel personListPanel;
     private ResultDisplay resultDisplay;
     @FXML
@@ -65,12 +72,48 @@ public class MainWindow extends UiPart<Stage> {
 
         // Set dependencies
         this.primaryStage = primaryStage;
+        this.initializeListener();
         this.logic = logic;
+        this.selectedPersonDetailCard = null;
+        this.currentFocusItem = null;
 
         // Configure the UI
         setWindowDefaultSize(logic.getGuiSettings());
 
         setAccelerators();
+    }
+
+    /**
+     * Updates current focus item to provided focus item.
+     *
+     * @param focusItem the focusItem to update
+     */
+    public void updateCurrentFocusItem(FocusItems focusItem) {
+        currentFocusItem = focusItem;
+        ShiftTabFocusable shiftTabFocusable = currentFocusItem.getItem(this);
+        assert(shiftTabFocusable != null);
+        shiftTabFocusable.focus();
+    }
+
+    /**
+     * Initializes the shift+tab button listener.
+     */
+    @FXML
+    public void initializeListener() {
+        // declare key combination for Shift + Tab
+        KeyCombination shiftTabCombination = new KeyCodeCombination(KeyCode.TAB, KeyCombination.SHIFT_DOWN);
+
+        // add listener
+        primaryStage.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            if (shiftTabCombination.match(event)) {
+                if (currentFocusItem != null) {
+                    FocusItems focusItem = currentFocusItem.next(this);
+                    this.updateCurrentFocusItem(focusItem);
+                }
+                event.consume();
+            }
+
+        });
     }
 
     public Stage getPrimaryStage() {
@@ -112,22 +155,33 @@ public class MainWindow extends UiPart<Stage> {
         });
     }
 
+
+
     /**
-     * Displays the details of the selected {@code Person} on the right pane.
+     * Sets the {@code selectedPersonDetailCard} field based on the provided selected index.
+     * This method creates a new {@code PersonDetailCard} using the specified index and
+     * updates the UI to reflect the selected person's details. If {@code selectedIndex} is equal
+     * to {@code CommandResult.NO_RECORD_SELECTED}, a default {@code PersonDetailFallback} card
+     * will be shown instead.
      *
-     * @param index of the selected {@code Person}
+     * @param selectedIndex the index of the selected person used to create the detail card
      */
-    protected void showSelectedPerson(int index) {
-        Person selectedPerson = logic.getFilteredPersonList().get(index);
-        PersonDetailCard personDetailCard = new PersonDetailCard(selectedPerson);
-        personDetailPlaceholder.getChildren().setAll(personDetailCard.getRoot());
+    protected void setAndShowSelectedPerson(int selectedIndex) {
+        if (selectedIndex == CommandResult.NO_RECORD_SELECTED) {
+            this.selectedPersonDetailCard = null;
+            personDetailPlaceholder.getChildren().setAll(personDetailFallback.getRoot());
+        } else {
+            Person selectedPerson = logic.getFilteredPersonList().get(selectedIndex);
+            this.selectedPersonDetailCard = new PersonDetailCard(selectedPerson);
+            personDetailPlaceholder.getChildren().setAll(this.selectedPersonDetailCard.getRoot());
+        }
     }
 
     /**
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        personListPanel = new PersonListPanel(logic.getFilteredPersonList(), this::showSelectedPerson);
+        personListPanel = new PersonListPanel(logic.getFilteredPersonList(), this::setAndShowSelectedPerson);
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
@@ -138,8 +192,9 @@ public class MainWindow extends UiPart<Stage> {
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
-        CommandBox commandBox = new CommandBox(this::executeCommand, this::autocompleteCommand, this::validateSyntax);
-        commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
+        this.commandBox = new CommandBox(this::executeCommand, this::autocompleteCommand, this::validateSyntax);
+        updateCurrentFocusItem(FocusItems.COMMAND_BOX_ITEM);
+        commandBoxPlaceholder.getChildren().add(this.commandBox.getRoot());
     }
 
     /**
@@ -206,13 +261,7 @@ public class MainWindow extends UiPart<Stage> {
             }
 
             int selectedIndex = commandResult.getSelectedIndex();
-            if (selectedIndex == CommandResult.NO_RECORD_SELECTED) {
-                // display fallback ui if no index is selected
-                personDetailPlaceholder.getChildren().setAll(personDetailFallback.getRoot());
-            } else {
-                // display detail page
-                showSelectedPerson(selectedIndex);
-            }
+            this.setAndShowSelectedPerson(selectedIndex);
 
             return commandResult;
         } catch (CommandException | ParseException e) {
@@ -248,6 +297,58 @@ public class MainWindow extends UiPart<Stage> {
         boolean isValidSyntax = logic.validateSyntax(syntax);
         logger.info("isValidSyntax: " + isValidSyntax);
         return isValidSyntax;
+    }
+
+    private enum FocusItems {
+        COMMAND_BOX_ITEM {
+            @Override
+            public ShiftTabFocusable getItem(MainWindow mainWindow) {
+                return mainWindow.commandBox;
+            }
+
+        },
+        LOG_LIST_ITEM {
+            @Override
+            public ShiftTabFocusable getItem(MainWindow mainWindow) {
+                return mainWindow.selectedPersonDetailCard;
+            }
+        },
+        PERSON_LIST_ITEM {
+            @Override
+            public ShiftTabFocusable getItem(MainWindow mainWindow) {
+                return mainWindow.personListPanel;
+            }
+        };
+
+        // Method to get the next focus item (gets next until item not null)
+        public FocusItems next(MainWindow mainWindow) {
+            int count = 0;
+            FocusItems next = values()[(this.ordinal() + 1) % values().length];
+            while(next.getItem(mainWindow) == null) {
+                // should not go into infinite loop, since focusItem is only set after
+                // command box have been initialized
+                assert(count <= values().length);
+                next = values()[(next.ordinal() + 1) % values().length];
+                count += 1;
+            }
+            return next;
+        }
+
+        // Method to get the previous focus item (gets previous until item not null)
+        public FocusItems previous(MainWindow mainWindow) {
+            int count = 0;
+            FocusItems previous = values()[(this.ordinal() - 1 + values().length) % values().length];
+            while(previous.getItem(mainWindow) == null) {
+                // should not go into infinite loop, since focusItem is only set after
+                // command box have been initialized
+                assert(count <= values().length);
+                previous = values()[(previous.ordinal() - 1 + values().length) % values().length];
+                count += 1;
+            }
+            return previous;
+        }
+
+        public abstract ShiftTabFocusable getItem(MainWindow mainWindow);
     }
 
 }

--- a/src/main/java/careconnect/ui/MainWindow.java
+++ b/src/main/java/careconnect/ui/MainWindow.java
@@ -6,12 +6,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.logging.Logger;
 
-import careconnect.Main;
 import careconnect.commons.core.GuiSettings;
 import careconnect.commons.core.LogsCenter;
 import careconnect.logic.Logic;
 import careconnect.logic.autocompleter.exceptions.AutocompleteException;
-import careconnect.logic.commands.Command;
 import careconnect.logic.commands.CommandResult;
 import careconnect.logic.commands.exceptions.CommandException;
 import careconnect.logic.parser.exceptions.ParseException;
@@ -172,14 +170,20 @@ public class MainWindow extends UiPart<Stage> {
      */
     protected void setAndShowSelectedPerson(int selectedIndex) {
         if (selectedIndex == CommandResult.NO_RECORD_SELECTED) {
+            this.personListPanel.clearSelection();
             this.selectedPersonDetailCard = null;
             personDetailPlaceholder.getChildren().setAll(personDetailFallback.getRoot());
         } else {
-            // this selects and the selection listener in personListPanel will show
+            // this selects and the selection listener in personListPanel will make a call to showSelectedPerson
             this.personListPanel.setSelected(selectedIndex);
         }
     }
 
+    /**
+     * Shows selected person on the right pane
+     *
+     * @param person the person to be shown
+     */
     protected void showSelectedPerson(Person person) {
         this.selectedPersonDetailCard = new PersonDetailCard(person, this::updateCurrentFocusItem);
         personDetailPlaceholder.getChildren().setAll(this.selectedPersonDetailCard.getRoot());
@@ -189,7 +193,7 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        personListPanel = new PersonListPanel(logic.getFilteredPersonList(), this::setAndShowSelectedPerson,
+        personListPanel = new PersonListPanel(logic.getFilteredPersonList(),
                 this::updateCurrentFocusItem, this::showSelectedPerson);
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
@@ -201,7 +205,8 @@ public class MainWindow extends UiPart<Stage> {
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
-        this.commandBox = new CommandBox(this::executeCommand, this::autocompleteCommand, this::validateSyntax, this::updateCurrentFocusItem);
+        this.commandBox = new CommandBox(this::executeCommand, this::autocompleteCommand,
+                this::validateSyntax, this::updateCurrentFocusItem);
         // focus on command box
         updateCurrentFocusItem(FocusItems.COMMAND_BOX_ITEM);
         commandBoxPlaceholder.getChildren().add(this.commandBox.getRoot());
@@ -332,7 +337,8 @@ public class MainWindow extends UiPart<Stage> {
             @Override
             public ShiftTabFocusable getItem(MainWindow mainWindow) {
                 // if no person selected or no logs present return null
-                if (mainWindow.selectedPersonDetailCard == null || mainWindow.selectedPersonDetailCard.isLogListEmpty()) {
+                if (mainWindow.selectedPersonDetailCard == null
+                        || mainWindow.selectedPersonDetailCard.isLogListEmpty()) {
                     return null;
                 } else {
                     return mainWindow.selectedPersonDetailCard;
@@ -350,7 +356,7 @@ public class MainWindow extends UiPart<Stage> {
         public FocusItems next(MainWindow mainWindow) {
             int count = 0;
             FocusItems next = values()[(this.ordinal() + 1) % values().length];
-            while(next.getItem(mainWindow) == null) {
+            while (next.getItem(mainWindow) == null) {
                 // should not go into infinite loop, since focusItem is only set after
                 // command box have been initialized
                 assert(count <= values().length);
@@ -364,7 +370,7 @@ public class MainWindow extends UiPart<Stage> {
         public FocusItems previous(MainWindow mainWindow) {
             int count = 0;
             FocusItems previous = values()[(this.ordinal() - 1 + values().length) % values().length];
-            while(previous.getItem(mainWindow) == null) {
+            while (previous.getItem(mainWindow) == null) {
                 // should not go into infinite loop, since focusItem is only set after
                 // command box have been initialized
                 assert(count <= values().length);

--- a/src/main/java/careconnect/ui/PersonCard.java
+++ b/src/main/java/careconnect/ui/PersonCard.java
@@ -1,7 +1,6 @@
 package careconnect.ui;
 
 import java.util.Comparator;
-import java.util.function.Consumer;
 
 import careconnect.model.person.Person;
 import javafx.fxml.FXML;
@@ -48,7 +47,7 @@ public class PersonCard extends UiPart<Region> {
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
      */
-    public PersonCard(Person person, int displayedIndex, Consumer<Integer> setAndShowSelectedPerson) {
+    public PersonCard(Person person, int displayedIndex) {
         super(FXML);
         this.person = person;
         id.setText(displayedIndex + ". ");
@@ -61,9 +60,5 @@ public class PersonCard extends UiPart<Region> {
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
 
-        // Attach event listener
-        cardPane.setOnMousePressed(e -> {
-            setAndShowSelectedPerson.accept(displayedIndex - 1); // Because the list is 0-indexed
-        });
     }
 }

--- a/src/main/java/careconnect/ui/PersonCard.java
+++ b/src/main/java/careconnect/ui/PersonCard.java
@@ -48,7 +48,7 @@ public class PersonCard extends UiPart<Region> {
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
      */
-    public PersonCard(Person person, int displayedIndex, Consumer<Integer> showSelectedPerson) {
+    public PersonCard(Person person, int displayedIndex, Consumer<Integer> setAndShowSelectedPerson) {
         super(FXML);
         this.person = person;
         id.setText(displayedIndex + ". ");
@@ -63,7 +63,7 @@ public class PersonCard extends UiPart<Region> {
 
         // Attach event listener
         cardPane.setOnMousePressed(e -> {
-            showSelectedPerson.accept(displayedIndex - 1); // Because the list is 0-indexed
+            setAndShowSelectedPerson.accept(displayedIndex - 1); // Because the list is 0-indexed
         });
     }
 }

--- a/src/main/java/careconnect/ui/PersonDetailCard.java
+++ b/src/main/java/careconnect/ui/PersonDetailCard.java
@@ -6,7 +6,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Comparator;
 
-import careconnect.ui.MainWindow.FocusItemUpdater;
 import careconnect.model.person.Person;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;

--- a/src/main/java/careconnect/ui/PersonDetailCard.java
+++ b/src/main/java/careconnect/ui/PersonDetailCard.java
@@ -19,7 +19,7 @@ import javafx.scene.text.Text;
  * An UI component that displays detailed information of a {@code Person} in the right pane of
  * the window.
  */
-public class PersonDetailCard extends UiPart<Region> {
+public class PersonDetailCard extends UiPart<Region> implements ShiftTabFocusable {
 
     private static final String FXML = "PersonDetailCard.fxml";
 
@@ -82,5 +82,16 @@ public class PersonDetailCard extends UiPart<Region> {
 
         logsListPanel = new LogListPanel(person.getLogs());
         logsListPanelPlaceHolder.getChildren().setAll(logsListPanel.getRoot());
+    }
+
+    /**
+     * Sets focus on the logs within the PersonDetailCard.
+     * Currently, logs are the only component in the PersonDetailCard
+     * that should be focusable with Shift + Tab navigation.
+     * This method directs the focus to logsListPanel by calling logsListPanel.focus().
+     */
+    @Override
+    public void focus() {
+        this.logsListPanel.focus();
     }
 }

--- a/src/main/java/careconnect/ui/PersonDetailCard.java
+++ b/src/main/java/careconnect/ui/PersonDetailCard.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Comparator;
 
+import careconnect.ui.MainWindow.FocusItemUpdater;
 import careconnect.model.person.Person;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
@@ -57,7 +58,7 @@ public class PersonDetailCard extends UiPart<Region> implements ShiftTabFocusabl
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
      */
-    public PersonDetailCard(Person person) {
+    public PersonDetailCard(Person person, MainWindow.FocusItemUpdater focusItemUpdater) {
         super(FXML);
         this.person = person;
         name.setText(person.getName().fullName);
@@ -80,7 +81,7 @@ public class PersonDetailCard extends UiPart<Region> implements ShiftTabFocusabl
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
 
-        logsListPanel = new LogListPanel(person.getLogs());
+        logsListPanel = new LogListPanel(person.getLogs(), focusItemUpdater);
         logsListPanelPlaceHolder.getChildren().setAll(logsListPanel.getRoot());
     }
 
@@ -93,5 +94,9 @@ public class PersonDetailCard extends UiPart<Region> implements ShiftTabFocusabl
     @Override
     public void focus() {
         this.logsListPanel.focus();
+    }
+
+    protected boolean isLogListEmpty() {
+        return this.logsListPanel.isLogListEmpty();
     }
 }

--- a/src/main/java/careconnect/ui/PersonListPanel.java
+++ b/src/main/java/careconnect/ui/PersonListPanel.java
@@ -14,7 +14,7 @@ import javafx.scene.layout.Region;
 /**
  * Panel containing the list of persons.
  */
-public class PersonListPanel extends UiPart<Region> {
+public class PersonListPanel extends UiPart<Region> implements ShiftTabFocusable{
     private static final String FXML = "PersonListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(PersonListPanel.class);
 
@@ -24,20 +24,25 @@ public class PersonListPanel extends UiPart<Region> {
     /**
      * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
      */
-    public PersonListPanel(ObservableList<Person> personList, Consumer<Integer> showSelectedPerson) {
+    public PersonListPanel(ObservableList<Person> personList, Consumer<Integer> setAndShowSelectedPerson) {
         super(FXML);
         personListView.setItems(personList);
-        personListView.setCellFactory(listView -> new PersonListViewCell(showSelectedPerson));
+        personListView.setCellFactory(listView -> new PersonListViewCell(setAndShowSelectedPerson));
+    }
+
+    @Override
+    public void focus() {
+        this.personListView.requestFocus();
     }
 
     /**
      * Custom {@code ListCell} that displays the graphics of a {@code Person} using a {@code PersonCard}.
      */
     class PersonListViewCell extends ListCell<Person> {
-        private final Consumer<Integer> showSelectedPerson;
+        private final Consumer<Integer> setAndShowSelectedPerson;
 
-        public PersonListViewCell(Consumer<Integer> showSelectedPerson) {
-            this.showSelectedPerson = showSelectedPerson;
+        public PersonListViewCell(Consumer<Integer> setAndShowSelectedPerson) {
+            this.setAndShowSelectedPerson = setAndShowSelectedPerson;
         }
         @Override
         protected void updateItem(Person person, boolean empty) {
@@ -47,7 +52,7 @@ public class PersonListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new PersonCard(person, getIndex() + 1, showSelectedPerson).getRoot());
+                setGraphic(new PersonCard(person, getIndex() + 1, setAndShowSelectedPerson).getRoot());
             }
         }
     }

--- a/src/main/java/careconnect/ui/PersonListPanel.java
+++ b/src/main/java/careconnect/ui/PersonListPanel.java
@@ -16,7 +16,7 @@ import javafx.scene.layout.Region;
 /**
  * Panel containing the list of persons.
  */
-public class PersonListPanel extends UiPart<Region> implements ShiftTabFocusable{
+public class PersonListPanel extends UiPart<Region> implements ShiftTabFocusable {
     private static final String FXML = "PersonListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(PersonListPanel.class);
 
@@ -26,18 +26,24 @@ public class PersonListPanel extends UiPart<Region> implements ShiftTabFocusable
     /**
      * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
      */
-    public PersonListPanel(ObservableList<Person> personList, Consumer<Integer> setAndShowSelectedPerson,
+    public PersonListPanel(ObservableList<Person> personList,
                            FocusItemUpdater focusItemUpdater, Consumer<Person> showSelectedPerson) {
         super(FXML);
         this.personListView.setItems(personList);
-        this.personListView.setCellFactory(listView -> new PersonListViewCell(setAndShowSelectedPerson));
+        this.personListView.setCellFactory(listView -> new PersonListViewCell());
         personListView.setOnMousePressed(event -> {
             focusItemUpdater.updateCurrentFocusItem(FocusItems.PERSON_LIST_ITEM);
         });
         // Add listener to respond to selection changes
-        personListView.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
-            showSelectedPerson.accept(newValue);
+        personListView.getSelectionModel().selectedItemProperty().addListener((observable, oldPerspm, newPerson) -> {
+            if (newPerson != null) {
+                showSelectedPerson.accept(newPerson);
+            }
         });
+    }
+
+    protected void clearSelection() {
+        personListView.getSelectionModel().clearSelection();
     }
 
     protected void setSelected(int index) {
@@ -53,11 +59,6 @@ public class PersonListPanel extends UiPart<Region> implements ShiftTabFocusable
      * Custom {@code ListCell} that displays the graphics of a {@code Person} using a {@code PersonCard}.
      */
     class PersonListViewCell extends ListCell<Person> {
-        private final Consumer<Integer> setAndShowSelectedPerson;
-
-        public PersonListViewCell(Consumer<Integer> setAndShowSelectedPerson) {
-            this.setAndShowSelectedPerson = setAndShowSelectedPerson;
-        }
         @Override
         protected void updateItem(Person person, boolean empty) {
             super.updateItem(person, empty);
@@ -66,7 +67,7 @@ public class PersonListPanel extends UiPart<Region> implements ShiftTabFocusable
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new PersonCard(person, getIndex() + 1, setAndShowSelectedPerson).getRoot());
+                setGraphic(new PersonCard(person, getIndex() + 1).getRoot());
             }
         }
 

--- a/src/main/java/careconnect/ui/PersonListPanel.java
+++ b/src/main/java/careconnect/ui/PersonListPanel.java
@@ -5,6 +5,8 @@ import java.util.logging.Logger;
 
 import careconnect.commons.core.LogsCenter;
 import careconnect.model.person.Person;
+import careconnect.ui.MainWindow.FocusItemUpdater;
+import careconnect.ui.MainWindow.FocusItems;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
@@ -24,10 +26,22 @@ public class PersonListPanel extends UiPart<Region> implements ShiftTabFocusable
     /**
      * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
      */
-    public PersonListPanel(ObservableList<Person> personList, Consumer<Integer> setAndShowSelectedPerson) {
+    public PersonListPanel(ObservableList<Person> personList, Consumer<Integer> setAndShowSelectedPerson,
+                           FocusItemUpdater focusItemUpdater, Consumer<Person> showSelectedPerson) {
         super(FXML);
-        personListView.setItems(personList);
-        personListView.setCellFactory(listView -> new PersonListViewCell(setAndShowSelectedPerson));
+        this.personListView.setItems(personList);
+        this.personListView.setCellFactory(listView -> new PersonListViewCell(setAndShowSelectedPerson));
+        personListView.setOnMousePressed(event -> {
+            focusItemUpdater.updateCurrentFocusItem(FocusItems.PERSON_LIST_ITEM);
+        });
+        // Add listener to respond to selection changes
+        personListView.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
+            showSelectedPerson.accept(newValue);
+        });
+    }
+
+    protected void setSelected(int index) {
+        personListView.getSelectionModel().select(index);
     }
 
     @Override
@@ -55,6 +69,8 @@ public class PersonListPanel extends UiPart<Region> implements ShiftTabFocusable
                 setGraphic(new PersonCard(person, getIndex() + 1, setAndShowSelectedPerson).getRoot());
             }
         }
+
+
     }
 
 }

--- a/src/main/java/careconnect/ui/ShiftTabFocusable.java
+++ b/src/main/java/careconnect/ui/ShiftTabFocusable.java
@@ -1,0 +1,11 @@
+package careconnect.ui;
+
+/**
+ * interface for focusable ui components
+ */
+public interface ShiftTabFocusable {
+    /**
+     * Focuses the component
+     */
+    void focus();
+}

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -92,6 +92,13 @@
     -fx-background-color: derive(#FFFFFF, 20%);
 }
 
+/* Style when the ListView is focused */
+.list-view:focused {
+    -fx-border-color: #FFCC00;
+    -fx-border-width: 2px;
+    -fx-border-radius: 4px;
+}
+
 /* Styles the contact info cell */
 .list-cell {
     -fx-label-padding: 0 0 0 0;

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -94,7 +94,7 @@
 
 /* Style when the ListView is focused */
 .list-view:focused {
-    -fx-border-color: #FFCC00;
+    -fx-border-color: -fx-focus;
     -fx-border-width: 2px;
     -fx-border-radius: 4px;
 }

--- a/src/main/resources/view/theme.css
+++ b/src/main/resources/view/theme.css
@@ -5,6 +5,7 @@
     -fx-primary: #FFBF61;
     -fx-secondary: #E9EED9;
     -fx-secondary-bg: #FEF9F2;
+    -fx-focus: #FFCC00;
     -fx-link: #3e7b91;
     -fx-error: #d06651;
 }


### PR DESCRIPTION
fixes #130 

Changes made
1) Pressing shift+tab will cycle focus between command box, log list(if available) and person list pane
2) whenever a selected index is returned from command result, now the corresponding person card will be highlighted in person list pane
3) Arrow keys scrolling in person list panel now also updates the person detail card on the right pane