### PR TITLE
Make toString methods consistent

### DIFF
--- a/src/main/java/careconnect/logic/commands/AddLogCommand.java
+++ b/src/main/java/careconnect/logic/commands/AddLogCommand.java
@@ -114,9 +114,8 @@ public class AddLogCommand extends Command {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("log", log)
                 .add("targetIndex", targetIndex)
+                .add("log", log)
                 .toString();
     }
-
 }

--- a/src/main/java/careconnect/logic/commands/AddLogCommand.java
+++ b/src/main/java/careconnect/logic/commands/AddLogCommand.java
@@ -115,6 +115,7 @@ public class AddLogCommand extends Command {
     public String toString() {
         return new ToStringBuilder(this)
                 .add("log", log)
+                .add("targetIndex", targetIndex)
                 .toString();
     }
 

--- a/src/main/java/careconnect/logic/commands/DeleteLogCommand.java
+++ b/src/main/java/careconnect/logic/commands/DeleteLogCommand.java
@@ -122,9 +122,7 @@ public class DeleteLogCommand extends Command {
         DeleteLogCommand otherDeleteLogCommand = (DeleteLogCommand) other;
 
         return personIndex.equals(otherDeleteLogCommand.personIndex)
-                && logIndex.equals(otherDeleteLogCommand.logIndex)
-                && (requireConfirmation // if confirmation not completed, deletedLog is null
-                || deletedLog.equals(otherDeleteLogCommand.deletedLog));
+                && logIndex.equals(otherDeleteLogCommand.logIndex);
     }
 
     @Override
@@ -132,7 +130,6 @@ public class DeleteLogCommand extends Command {
         return new ToStringBuilder(this)
                 .add("personIndex", personIndex)
                 .add("logIndex", logIndex)
-                .add("deletedLog", deletedLog)
                 .toString();
     }
 }

--- a/src/main/java/careconnect/logic/commands/DeleteLogCommand.java
+++ b/src/main/java/careconnect/logic/commands/DeleteLogCommand.java
@@ -130,6 +130,8 @@ public class DeleteLogCommand extends Command {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
+                .add("personIndex", personIndex)
+                .add("logIndex", logIndex)
                 .add("deletedLog", deletedLog)
                 .toString();
     }

--- a/src/test/java/careconnect/logic/commands/AddLogCommandTest.java
+++ b/src/test/java/careconnect/logic/commands/AddLogCommandTest.java
@@ -71,8 +71,8 @@ public class AddLogCommandTest {
     @Test
     public void toStringMethod() {
         AddLogCommand addLogCommand = new AddLogCommand(INDEX_FIRST_PERSON, log1);
-        String expected = AddLogCommand.class.getCanonicalName() +
-                "{targetIndex=" + INDEX_FIRST_PERSON + ", log=" + log1 + "}";
+        String expected = AddLogCommand.class.getCanonicalName()
+                + "{targetIndex=" + INDEX_FIRST_PERSON + ", log=" + log1 + "}";
         assertEquals(expected, addLogCommand.toString());
     }
 }

--- a/src/test/java/careconnect/logic/commands/AddLogCommandTest.java
+++ b/src/test/java/careconnect/logic/commands/AddLogCommandTest.java
@@ -71,7 +71,8 @@ public class AddLogCommandTest {
     @Test
     public void toStringMethod() {
         AddLogCommand addLogCommand = new AddLogCommand(INDEX_FIRST_PERSON, log1);
-        String expected = AddLogCommand.class.getCanonicalName() + "{log=" + log1 + "}";
+        String expected = AddLogCommand.class.getCanonicalName() +
+                "{targetIndex=" + INDEX_FIRST_PERSON + ", log=" + log1 + "}";
         assertEquals(expected, addLogCommand.toString());
     }
 }

--- a/src/test/java/careconnect/logic/commands/DeleteLogCommandTest.java
+++ b/src/test/java/careconnect/logic/commands/DeleteLogCommandTest.java
@@ -87,4 +87,12 @@ public class DeleteLogCommandTest {
         // different log same person -> returns false
         assertFalse(deleteLogCommand3.equals(deleteLogCommand4));
     }
+
+    @Test
+    public void toStringMethod() {
+        DeleteLogCommand deleteLogCommand = new DeleteLogCommand(INDEX_FIRST_PERSON, INDEX_FIRST_LOG);
+        String expected = DeleteLogCommand.class.getCanonicalName() +
+                "{personIndex=" + INDEX_FIRST_PERSON + ", logIndex=" + INDEX_FIRST_LOG + "}";
+        assertEquals(expected, deleteLogCommand.toString());
+    }
 }

--- a/src/test/java/careconnect/logic/commands/DeleteLogCommandTest.java
+++ b/src/test/java/careconnect/logic/commands/DeleteLogCommandTest.java
@@ -91,8 +91,8 @@ public class DeleteLogCommandTest {
     @Test
     public void toStringMethod() {
         DeleteLogCommand deleteLogCommand = new DeleteLogCommand(INDEX_FIRST_PERSON, INDEX_FIRST_LOG);
-        String expected = DeleteLogCommand.class.getCanonicalName() +
-                "{personIndex=" + INDEX_FIRST_PERSON + ", logIndex=" + INDEX_FIRST_LOG + "}";
+        String expected = DeleteLogCommand.class.getCanonicalName()
+                + "{personIndex=" + INDEX_FIRST_PERSON + ", logIndex=" + INDEX_FIRST_LOG + "}";
         assertEquals(expected, deleteLogCommand.toString());
     }
 }


### PR DESCRIPTION
resolves #153 

updated `equal` and `toString` methods of AddLogCommand and DeleteLogCommand to be consistent with other commands