### PR TITLE
fix: amend find command error message

### DIFF
--- a/src/main/java/careconnect/logic/commands/FindCommand.java
+++ b/src/main/java/careconnect/logic/commands/FindCommand.java
@@ -15,8 +15,9 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Find contacts based on the given specifiers "
+            + "(at least 1 specifier required) and keywords (case-insensitive), and display them as a list with "
+            + "index numbers.\n"
             + "Parameters: n/ NAME [MORE_NAMES] a/ ADDRESS [MORE_ADDRESSES] t/ TAG [MORE_TAGS]\n"
             + "Example: " + COMMAND_WORD + " n/ alice bob charlie a/Serangoon t/friend";
 

--- a/src/main/java/careconnect/logic/parser/FindCommandParser.java
+++ b/src/main/java/careconnect/logic/parser/FindCommandParser.java
@@ -26,9 +26,6 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-        } else if (trimmedArgs.length() < 2) {
-            throw new ParseException(
-                    String.format(Messages.MESSAGE_TOO_SHORT_SEARCH, FindCommand.MESSAGE_USAGE));
         }
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_ADDRESS, CliSyntax.PREFIX_TAG);


### PR DESCRIPTION
fix #197 
fix #193 

This is a bug because the find command actually does not accept any parameters without specifiers (as stated in the UG). In this case, it's giving a wrong error message saying that the length is too short, when the whole command is actually invalid